### PR TITLE
Draw modes page and LODs doc update.

### DIFF
--- a/source/en/ToolReference/drawMode.md
+++ b/source/en/ToolReference/drawMode.md
@@ -1,0 +1,48 @@
+# Draw Modes 
+
+An editor can display particles in several draw modes, useful for debugging various aspects 
+of the edited effect.
+
+## Normal
+
+```eval_rst
+.. image:: ../../img/Reference/DrawMode_Normal.png
+   :align: center
+```
+
+This is the default draw mode. It displayed particles the same way as they will be rendered in
+the engine.
+
+## Wireframe
+
+```eval_rst
+.. image:: ../../img/Reference/DrawMode_Wireframe.png
+   :align: center
+```
+
+Shows wireframe representation of particles
+
+## Wireframe + Normal
+
+```eval_rst
+.. image:: ../../img/Reference/DrawMode_WireframeNormal.png
+   :align: center
+```
+
+
+Displayed textures particles with wireframe overlaid
+
+## Overdraw
+
+```eval_rst
+.. image:: ../../img/Reference/DrawMode_Overdraw.png
+   :align: center
+```
+
+
+This is mode is useful during optimization. It renders transparent "silhouettes" of particles. 
+These transparent colors accumulate which makes it easy to spot places where multiple particles 
+overlap. 
+
+High particles overdraw is usually the main source of performance issues, so you probably want
+to reduce overdraw when possible by reducing amount of overlapping particles.

--- a/source/en/ToolReference/index.md
+++ b/source/en/ToolReference/index.md
@@ -187,6 +187,7 @@ It can be imported and used in another project of yourself or someone else.
     fileImport
     fileExport
     recoveringData
+    drawMode
 ```
 
 ## Command Line

--- a/source/en/ToolReference/index.md
+++ b/source/en/ToolReference/index.md
@@ -158,6 +158,7 @@ It can be imported and used in another project of yourself or someone else.
     fcurve
     global
     culling
+    levelsOfDetails
     dynamicParameter
     proceduralModel
 ```

--- a/source/en/ToolReference/levelsOfDetails.md
+++ b/source/en/ToolReference/levelsOfDetails.md
@@ -1,0 +1,7 @@
+# Levels Of Details
+
+## Overview
+This window configures enabled of levels of details and distances from which they're utilized.
+
+See [Levels of Details Tutorial](../ToolTutorial/14.md) to learn more about what Levels of Details 
+are and how to use them.

--- a/source/en/ToolReference/top.html
+++ b/source/en/ToolReference/top.html
@@ -59,6 +59,7 @@ The ".efk" file can be exported from "File -> output" within the Effekseer edito
 			<li><a href="culling.html">Culling</a></li>
 			<li><a href="behavior.html">Behavior</a></li>
 			<li><a href="record.html">Recorder</a></li>
+			<li><a href="drawMode.html">Draw Modes</a></li>
 			<li><a href="options.html">Option</a></li>
 
 		</ul>

--- a/source/en/ToolTutorial/14.md
+++ b/source/en/ToolTutorial/14.md
@@ -119,5 +119,5 @@ of your effect production process when you're satisfied with effect look.
 
 Level of Details are quite versatile and can be setup in various ways, you can even completely replace
 effect at the certain distance by making separate root nodes for different level. Effect optimisation 
-process can be tricky but sometimes it's what separates you game from barely runnable at 30 fps and stable 60 fps,
-so it's a good idea to optimise effects when you can.
+process can be tricky, but sometimes it's what separates the game which barely runs at 30 fps from running
+at stable 60 fps.


### PR DESCRIPTION
This PR adds Draw Modes page which describes Normal/Wireframe/Overdraw draw modes. I also added a page with reference to LODs tutorial to effect parameters pages to make it a bit more discoverable. 